### PR TITLE
Add support for the remaining scroll events

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,11 @@ scrollEnabled | boolean | true | enables scrolling
 bounces | boolean | true | bounces
 refreshing | boolean | undefined | refreshing
 onRefresh | () => any | undefined | callback of pulling to refresh,if not undefined ,a default RefreshControl is add to LargeList
-onScroll | ({nativeEvent:{contentOffset:{x:number,y:number}}})=> any |  | Callback when scrolling.
+onMomentumScrollBegin | ({nativeEvent:{contentOffset:{x:number,y:number}}})=> any |  | Called when the momentum scroll starts (scroll which occurs as the ScrollView glides to a stop).
+onMomentumScrollEnd | ({nativeEvent:{contentOffset:{x:number,y:number}}})=> any |  | Called when the momentum scroll ends (scroll which occurs as the ScrollView glides to a stop).
+onScroll | ({nativeEvent:{contentOffset:{x:number,y:number}}})=> any |  | Fires at most once per frame during scrolling. The frequency of the events can be controlled using the scrollEventThrottle prop.
+onScrollBeginDrag | ({nativeEvent:{contentOffset:{x:number,y:number}}})=> any |  | Called when the user begins to drag the scroll view.
+onScrollEndDrag | ({nativeEvent:{contentOffset:{x:number,y:number}}})=> any |  | Called when the user stops dragging the scroll view and it either stops or begins to glide.
 
 Notice:
 

--- a/react-native-largelist/largelist/LargeList.js
+++ b/react-native-largelist/largelist/LargeList.js
@@ -66,7 +66,11 @@ class LargeList extends React.Component {
     refreshing: PropTypes.bool,
     dynamicMargin: PropTypes.number,
     scrollEventThrottle: PropTypes.number,
+    onMomentumScrollBegin: PropTypes.func,
+    onMomentumScrollEnd: PropTypes.func,
     onScroll: PropTypes.func,
+    onScrollBeginDrag: PropTypes.func,
+    onScrollEndDrag: PropTypes.func,
 
     speedLevel1: PropTypes.number,
     speedLevel2: PropTypes.number,
@@ -364,8 +368,11 @@ class LargeList extends React.Component {
             onLayout={this._onLayout.bind(this)}
             style={{ flex: 1 }}
             scrollEventThrottle={this.props.scrollEventThrottle}
-            onScroll={this._onScroll.bind(this)}
+            onMomentumScrollBegin={this.props.onMomentumScrollBegin}
             onMomentumScrollEnd={this._onScrollEnd.bind(this)}
+            onScroll={this._onScroll.bind(this)}
+            onScrollBeginDrag={this.props.onScrollBeginDrag}
+            onScrollEndDrag={this.props.onScrollEndDrag}
             showsVerticalScrollIndicator={
               this.props.showsVerticalScrollIndicator
             }
@@ -1136,7 +1143,8 @@ class LargeList extends React.Component {
     this.scrollingAfterDraging = true;
   }
 
-  _onScrollEnd() {
+  _onScrollEnd(e) {
+    this.props.onMomentumScrollEnd && this.props.onMomentumScrollEnd(e);
     this.lastScrollTime = 0;
     if (
       this.scrollingAfterDraging &&


### PR DESCRIPTION
This allows you to use all of the scroll events that a `ScrollView` supports. This is very useful for animations which track the scrolling of the list.