### PR TITLE
Performance improvement: LargeListCell should never automatically update

### DIFF
--- a/react-native-largelist/largelist/LargeListCell.js
+++ b/react-native-largelist/largelist/LargeListCell.js
@@ -59,6 +59,10 @@ class LargeListCell extends React.Component {
   _maxLeftWidth: number = 250;
   _enableShowEx: boolean = false;
 
+  shouldComponentUpdate() {
+    return false;
+  }
+
   contentUpdate() {
     this.waitForRender = false;
     if (this.locationUpdated) this.positionUpdate();


### PR DESCRIPTION
I have been trying to improve the render performance of this list on start up and when I update the data. (i.e. searches)

With a list of 20 items in my app, the callback function renderCell fires over 250 times on first load. With this change, I got this down to 60. 

My experience with this library is, for all updates to list data, I need to manually trigger a re-render. If this is not true, this PR should not be considered as it stops all re-renders made by react.

If you decide to close this pr without merging, please indicate why since I am looking to use this modified version in our app.