### PR TITLE
Fix onScroll event and scrollTo animated param

### DIFF
--- a/src/NativeLargeList.js
+++ b/src/NativeLargeList.js
@@ -218,7 +218,7 @@ export class NativeLargeList extends React.PureComponent<LargeListPropType> {
       idx(() =>
         this._sectionContainer.current.updateOffset(this._contentOffsetY)
       );
-    this.props.onScroll && this.props.onScroll(offset);
+    this.props.onScroll && this.props.onScroll(e);
   };
 
   _scrollEvent = Animated.event(
@@ -243,7 +243,7 @@ export class NativeLargeList extends React.PureComponent<LargeListPropType> {
     );
     idx(() => this._sectionContainer.current.updateOffset(offset.y));
     return new Promise((r, j) => {
-      this._scrollView.current.getNode().scrollTo(offset, animated);
+      this._scrollView.current.getNode().scrollTo({ ...offset, animated });
 
       setTimeout(() => {
         r();


### PR DESCRIPTION
- Pass the actual event instead of `offset` (which is not a thing) to `onScroll`
- Fix `animated` param passed to `scrollTo` as per [documentation](https://facebook.github.io/react-native/docs/scrollview#scrollto)