### PR TITLE
Include missing LargeListPropType

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -31,6 +31,7 @@ declare module "react-native-largelist-v3" {
     groupCount?: number;
     groupMinHeight?: number;
     updateTimeInterval?: number;
+    headerStickyEnabled?: boolean;
   }
 
   export class LargeList extends React.PureComponent<LargeListPropType> {


### PR DESCRIPTION
Fixes this type error due to a missing prop type declaration in TypeScript projects.

```
Property 'headerStickyEnabled' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<LargeList> & Readonly<LargeListPropType> & Readonly<{ children?: ReactNode; }>'.
```