### PR TITLE
rename componentWillReceiveProps with UNSAFE_componentWillReceiveProps

### DIFF
--- a/src/Group.js
+++ b/src/Group.js
@@ -41,7 +41,7 @@ export class Group extends React.Component<GroupPropType> {
     !init && this.forceUpdate();
   }
 
-  componentWillReceiveProps(next: GroupPropType) {
+  UNSAFE_componentWillReceiveProps(next: GroupPropType) {
     if (next.offset) {
       this._offset = null;
       this.contentConversion(next.offset);

--- a/src/LargeList.js
+++ b/src/LargeList.js
@@ -53,7 +53,7 @@ export class LargeList extends React.PureComponent<LargeListPropType> {
     }
   }
 
-  componentWillReceiveProps(props: LargeListPropType) {
+  UNSAFE_componentWillReceiveProps(props: LargeListPropType) {
     if (
       props.onNativeContentOffsetExtract &&
       this.props.onNativeContentOffsetExtract !== props.onNativeContentOffsetExtract

--- a/src/Section.js
+++ b/src/Section.js
@@ -25,7 +25,7 @@ export class Section extends React.Component<SectionPropType> {
     this.updateOffset(offset, true);
   }
 
-  componentWillReceiveProps(next: SectionPropType) {
+  UNSAFE_componentWillReceiveProps(next: SectionPropType) {
     this.updateOffset(next.offset, false, next);
   }
 

--- a/src/StickyForm.js
+++ b/src/StickyForm.js
@@ -26,7 +26,7 @@ export class StickyForm extends React.PureComponent<StickyFormPropType> {
     this.obtainOffset();
   }
 
-  componentWillReceiveProps(props: LargeListPropType) {
+  UNSAFE_componentWillReceiveProps(props: LargeListPropType) {
     if (
       props.onNativeContentOffsetExtract &&
       this.props.onNativeContentOffsetExtract !== props.onNativeContentOffsetExtract

--- a/src/WaterfallItem.js
+++ b/src/WaterfallItem.js
@@ -21,7 +21,7 @@ export class WaterfallItem extends React.Component<WaterfallItemType> {
     this.updateOffset(props.offset, true);
   }
 
-  componentWillReceiveProps(next: WaterfallItemType) {
+  UNSAFE_componentWillReceiveProps(next: WaterfallItemType) {
     this.updateOffset(next.offset, false, next);
   }
 

--- a/src/WaterfallList.js
+++ b/src/WaterfallList.js
@@ -36,7 +36,7 @@ export class WaterfallList extends React.PureComponent<WaterfallListType> {
     this.obtainOffset();
   }
 
-  componentWillReceiveProps(props: LargeListPropType) {
+  UNSAFE_componentWillReceiveProps(props: LargeListPropType) {
     if (
       props.onNativeContentOffsetExtract &&
       this.props.onNativeContentOffsetExtract !== props.onNativeContentOffsetExtract


### PR DESCRIPTION
Getting some errors in our start script about the update with React 17 where only UNSAFE_ will work
```
* Rename componentWillReceiveProps to UNSAFE_componentWillReceiveProps to suppress this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.

Please update the following components: LargeList, SpringScrollView
 WARN  Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://fb.me/react-async-component-lifecycle-hooks for details.
```