### PR TITLE
Correct onScroll throttling

### DIFF
--- a/src/LargeList.js
+++ b/src/LargeList.js
@@ -451,8 +451,7 @@ export class LargeList extends React.PureComponent<LargeListPropType> {
       );
     this.props.onScroll && this.props.onScroll(e);
     const now = new Date().getTime();
-    if (this._lastTick - now > 30) {
-      this._lastTick = now;
+    if (now - this._lastTick < this.props.updateTimeInterval) {
       return;
     }
     this._lastTick = now;

--- a/src/WaterfallList.js
+++ b/src/WaterfallList.js
@@ -300,8 +300,7 @@ export class WaterfallList extends React.PureComponent<WaterfallListType> {
   _onScroll = e => {
     this._contentOffsetY = e.nativeEvent.contentOffset.y;
     const now = new Date().getTime();
-    if (this._lastTick - now > 30) {
-      this._lastTick = now;
+    if (now - this._lastTick < 30) {
       return;
     }
     this._lastTick = now;


### PR DESCRIPTION
Problem I observed is detailed here: https://github.com/bolan9999/react-native-largelist/issues/466

This PR corrects the logic in two ways:
1) Changes the throttle to compare numbers in correct direction, before the if condition was always false.
2) Start utilizing the `updateTimeInterval` prop which was previously being ignored throughout the code.

Wasn't totally sure about number 2, but my read was this was the logical place to control that logic.